### PR TITLE
fix IllegalArgumentException after restart

### DIFF
--- a/docroot/WEB-INF/src/com/marcelmika/lims/conversation/MUConversation.java
+++ b/docroot/WEB-INF/src/com/marcelmika/lims/conversation/MUConversation.java
@@ -64,6 +64,8 @@ public class MUConversation implements Conversation, JSONable {
     public void restart() {
         // Delete old stuff
         messages.clear();
+        lastMessageSent = 0;//reset
+        
         participants.clear();
         // Reset creating flow
         join(muc);


### PR DESCRIPTION
fix bug:
java.lang.IllegalArgumentException: fromIndex(7) > toIndex(0) 
at java.util.SubList.<init>(AbstractList.java:624) 
at java.util.AbstractList.subList(AbstractList.java:484) 
at com.marcelmika.lims.conversation.MUConversation.toFullJSON(MUConversation.java:395)
